### PR TITLE
fixed to require input of containers-config-json parameter

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ inputs:
         required: false
     containers-config-json:
         description: 'Container Config'
-        required: false
+        required: true
 
 outputs:
     container-result:


### PR DESCRIPTION
The requirement for the `containers-config-json` parameter was not consistent between [action.yml](https://github.com/Azure/aca-deploy/blob/main/action.yml) and [taskparameters.ts](https://github.com/Azure/aca-deploy/blob/main/src/taskparameters.ts), so I verified it. As a result, it was found that the parameter was required, and the code was fixed.