### PR TITLE
Minimally fixed errors where values were not passed

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -11,12 +11,14 @@ async function main() {
 
 // Please refer to this sample code
 // https://github.com/Azure/azure-sdk-for-js/blob/32c07776aa91c302fb2c90ba65e3bb4668b5a792/sdk/appcontainers/arm-appcontainers/samples-dev/containerAppsCreateOrUpdateSample.ts
+
   try {
     // Set user agent variable.
     let usrAgentRepo = crypto.createHash('sha256').update(`${process.env.GITHUB_REPOSITORY}`).digest('hex');
     let actionName = 'DeployAzureContainerApp';
     let userAgentString = (!!prefix ? `${prefix}+` : '') + `GITHUBACTIONS_${actionName}_${usrAgentRepo}`;
     core.exportVariable('AZURE_HTTP_USER_AGENT', userAgentString);
+
     var taskParams = TaskParameters.getTaskParams();
     let credential: TokenCredential = new DefaultAzureCredential()
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,14 +11,12 @@ async function main() {
 
 // Please refer to this sample code
 // https://github.com/Azure/azure-sdk-for-js/blob/32c07776aa91c302fb2c90ba65e3bb4668b5a792/sdk/appcontainers/arm-appcontainers/samples-dev/containerAppsCreateOrUpdateSample.ts
-
   try {
     // Set user agent variable.
     let usrAgentRepo = crypto.createHash('sha256').update(`${process.env.GITHUB_REPOSITORY}`).digest('hex');
     let actionName = 'DeployAzureContainerApp';
     let userAgentString = (!!prefix ? `${prefix}+` : '') + `GITHUBACTIONS_${actionName}_${usrAgentRepo}`;
     core.exportVariable('AZURE_HTTP_USER_AGENT', userAgentString);
-
     var taskParams = TaskParameters.getTaskParams();
     let credential: TokenCredential = new DefaultAzureCredential()
 
@@ -29,32 +27,60 @@ async function main() {
     const client = new ContainerAppsAPIClient(credential, taskParams.subscriptionId);
 
     // TBD: Remove key when there is key without value
-    const daprConfig = {
+    const daprConfig: {
+      appPort?: number,
+      appProtocol?: string,
+      enabled: boolean
+    } = {
       appPort: taskParams.daprAppPort, 
       appProtocol: taskParams.daprAppProtocol, 
       enabled: taskParams.daprEnabled
     };
+    if (isNaN(taskParams.daprAppPort)) {
+      delete daprConfig.appPort
+    };
+    if (taskParams.daprAppProtocol == "") {
+      delete daprConfig.appProtocol
+    };
 
     // TBD: Remove key when there is key without value
-    const ingresConfig = {
+    const ingresConfig: {
+      external: boolean,
+      targetPort?: number,
+      traffic?: any[],
+      customDomains?: any[]
+    } = {
       external: taskParams.ingressExternal, 
       targetPort: taskParams.ingressTargetPort, 
       // traffic: taskParams.ingressTraffic, 
       // customDomains: taskParams.ingressCustomDomains
-    } 
+    };
+    if (taskParams.ingressTraffic.length == 0) {
+      delete ingresConfig.traffic
+    };
 
     let scaleRules = taskParams.scaleRules
     // TBD: Remove key when there is key without value
-    const scaleConfig = {
+    const scaleConfig: {
+      maxReplicas: number,
+      minReplicas: number,
+      rules: any[]
+    } = {
       maxReplicas: taskParams.scaleMaxReplicas, 
       minReplicas: taskParams.scaleMinReplicas, 
       rules: scaleRules 
-    }
+    };
 
-    let networkConfig = {
-      "dapr": daprConfig,
-      "ingress": ingresConfig
-    }
+    let networkConfig: {
+      dapr: object,
+      ingress?: object
+    } = {
+      dapr: daprConfig,
+      ingress: ingresConfig
+    };
+    if (taskParams.ingressExternal == false) {
+      delete networkConfig.ingress
+    };
 
     // TBD: Find a way to get a value instead of json
     const containersConfig = taskParams.containersConfig


### PR DESCRIPTION
_English follows Japanese_


`TBD: Remove key when there is key without value`に対して，値が渡されなかった場合にエラーになるパラメータのみ削除するように最低限の修正をしました．逆にいうと値が渡されなくてもエラーが出ないところは削除していません．つきましては`daprConfig`・`ingresConfig`・`scaleConfig`それぞれに対して排他的設定の調査も含めた検証を行ったので結果をシェアします．

### `daprConfig`について
- `appPort`と`appProtocol`は値が与えられていない場合，キーを削除しないとエラーが出る（`enabled`の値に関わらず）
- `enabled==false`の時に，`appPort`と`appProtocol`の値が与えられていてもエラーがは出ない

### `ingresConfig`について
- `external==false`の時は，`networkConfig.ingress`に入れるだけでエラーになるので，`ingresConfig`自体を破棄/無視する必要がある
- `external==true`なら必ず`targetPort`の値が必要
- `traffic`は値が与えられていない場合，キーを削除しないとエラーが出る

### `scaleConfig`について
- 全てのパラメータは値を与えられていなくてもエラーにならない
- どれか一つのパラメータだけ値が与えられていても（いなくても）エラーにならない（排他的な設定はない）

---

`TBD: Remove key when there is key without value` has been minimally fixed to remove only those parameters that cause an error if no value is passed. Conversely, I have not removed the parameters that do not cause an error if no value is passed. Therefore, I have performed a verification of `daprConfig`, `ingresConfig`, and `scaleConfig`, including an investigation of the exclusive setting, and I will share the results with you.

### About `daprConfig
- When `appPort` and `appProtocol` are not given values, an error occurs if the key is not deleted (regardless of the value of `enabled`)
- When `enabled==false`, no error occurs even if `appPort` and `appProtocol` values are given

### About `ingresConfig`
- When `external==false`, just putting the value in `networkConfig.ingress` causes an error, so you need to discard/ignore `ingresConfig` itself.
- If `external===true`, the value of `targetPort` is always required.
- If `traffic` is not given a value, you have to delete the key to get an error.

### About `scaleConfig`
- All parameters are error-free even if no value is given
- No error (no exclusive setting) even if only one parameter is given a value (or not)