### PR TITLE
get subscription id by credential

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "dependencies": {
     "@actions/core": "^1.9.1",
     "@azure/arm-appcontainers": "^1.1.0",
-    "@azure/identity": "^2.1.0"
+    "@azure/identity": "^2.1.0",
+    "azure-actions-webclient": "^1.0.10"
   },
   "devDependencies": {
     "@types/node": "^13.13.52",

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,8 @@ import * as core from "@actions/core";
 import * as crypto from "crypto";
 import { ContainerAppsAPIClient, ContainerApp } from "@azure/arm-appcontainers";
 import { TokenCredential, DefaultAzureCredential } from "@azure/identity";
+import { AuthorizerFactory } from "azure-actions-webclient/AuthorizerFactory";
+import { IAuthorizer } from "azure-actions-webclient/Authorizer/IAuthorizer";
 
 import { TaskParameters } from "./taskparameters";
 
@@ -19,7 +21,8 @@ async function main() {
     let userAgentString = (!!prefix ? `${prefix}+` : '') + `GITHUBACTIONS_${actionName}_${usrAgentRepo}`;
     core.exportVariable('AZURE_HTTP_USER_AGENT', userAgentString);
 
-    var taskParams = TaskParameters.getTaskParams();
+    let endpoint: IAuthorizer = await AuthorizerFactory.getAuthorizer();
+    var taskParams = TaskParameters.getTaskParams(endpoint);
     let credential: TokenCredential = new DefaultAzureCredential()
 
     // TBD: Need to get subscriptionId not from taskParams, but from credential.

--- a/src/taskparameters.ts
+++ b/src/taskparameters.ts
@@ -1,8 +1,10 @@
 import * as core from '@actions/core';
+import { IAuthorizer } from "azure-actions-webclient/Authorizer/IAuthorizer";
 import fs = require('fs');
   
 export class TaskParameters {
     private static taskparams: TaskParameters;
+    private _endpoint: IAuthorizer;
 
     // Required basic parameters
     private _resourceGroup: string;
@@ -31,10 +33,12 @@ export class TaskParameters {
     private _containersConfig: any[];
 
 
-    private constructor() {
+    private constructor(endpoint: IAuthorizer) {
+
+        this._endpoint = endpoint;
+        this._subscriptionId = endpoint.subscriptionID;
 
         // Required basic parameters
-        this._subscriptionId = core.getInput('subscription-id',{ required: true } );
         this._resourceGroup = core.getInput('resource-group', { required: true });
         this._containerAppName = core.getInput('name', { required: true });
         this._location = core.getInput('location', { required: true });
@@ -70,9 +74,9 @@ export class TaskParameters {
     // TBD: Need to validate that the specific params for scaleRules exist in the input json
     // TBD: Need to validate that the specific params for containersConfig like 'name' and 'image' exist in the input json
 
-    public static getTaskParams() {
+    public static getTaskParams(endpoint: IAuthorizer) {
         if(!this.taskparams) {
-            this.taskparams = new TaskParameters();
+            this.taskparams = new TaskParameters(endpoint);
         }
         return this.taskparams;
     }


### PR DESCRIPTION
Fix to get the subscription id from credential ( like aci deploy action ) instead of from taskparameter.